### PR TITLE
fixbug: 一些API会返回多余不相关数据

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ go build -o lainlet
 
 #### `/v2/configwatcher?target=<target>`
 返回`/lain/config/<target>`的值, 接收参数target, 如果不指定，则返回所有的配置值。格式为json
+target 会被作为所有配置项的前缀进行搜索，比如 `target=a` 的情况会把所有 `a` 开头的配置项都返回。
 
 #### `/v2/procwatcher`
 返回`/lain/config/pod_group/<appname>`的精简结构
@@ -73,6 +74,7 @@ go build -o lainlet
 
 #### `/v2/depends`
 返回 `/lain/deployd/depends/pods`下的数据的简化版本
+`target` 参数如果不指定，返回所有 depends 数据，如果指定，它则作为前缀匹配所有 depends，返回一部分。
 
 #### `/v2/nodes`
 返回 `/lain/nodes/nodes`下的数据的简化版本

--- a/api/v2/backupctl.go
+++ b/api/v2/backupctl.go
@@ -76,5 +76,8 @@ func (ci *CoreInfoForBackupctl) Key(r *http.Request) (string, error) {
 		return "", fmt.Errorf("authorize failed, super required")
 	}
 	appName := api.GetString(r, "appname", "*")
+	if appName != "*" {
+		appName = fixPrefix(appName)
+	}
 	return appName, nil
 }

--- a/api/v2/container.go
+++ b/api/v2/container.go
@@ -46,5 +46,8 @@ func (gc *GeneralContainers) Key(r *http.Request) (string, error) {
 		return "", fmt.Errorf("authorize failed, super required")
 	}
 	target := api.GetString(r, "nodename", "*")
+	if target != "*" {
+		target = fixPrefix(target)
+	}
 	return target, nil
 }

--- a/api/v2/coreinfo.go
+++ b/api/v2/coreinfo.go
@@ -114,9 +114,9 @@ func (gci *GeneralCoreInfo) Key(r *http.Request) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("authorize failed, can not confirm the app by request ip")
 			}
-			return appName, nil
+			return fixPrefix(appName), nil
 		}
 		return "", fmt.Errorf("authorize failed, no permission")
 	}
-	return appName, nil
+	return fixPrefix(appName), nil
 }

--- a/api/v2/localspec.go
+++ b/api/v2/localspec.go
@@ -54,7 +54,7 @@ func (ls *LocalSpec) Key(r *http.Request) (string, error) {
 	if !auth.IsSuper(r.RemoteAddr) {
 		return "", fmt.Errorf("authorize failed, super required")
 	}
-	return api.GetString(r, "nodeip", ls.LocalIP), nil
+	return fixPrefix(api.GetString(r, "nodeip", ls.LocalIP)), nil
 }
 
 // to realize BanWatcher interface, abandon watch action

--- a/api/v2/nodes.go
+++ b/api/v2/nodes.go
@@ -47,5 +47,8 @@ func (gn *GeneralNodes) Key(r *http.Request) (string, error) {
 		return "", fmt.Errorf("authorize failed, super required")
 	}
 	target := api.GetString(r, "name", "*")
+	if target != "*" && target[len(target)-1] != ':' {
+		target = target + ":"
+	}
 	return target, nil
 }

--- a/api/v2/podgroup.go
+++ b/api/v2/podgroup.go
@@ -81,5 +81,5 @@ func (gpg *GeneralPodGroup) Key(r *http.Request) (string, error) {
 	if !auth.Pass(r.RemoteAddr, appName) {
 		return "", fmt.Errorf("authorize failed, no permission")
 	}
-	return appName, nil
+	return fixPrefix(appName), nil
 }

--- a/api/v2/proxy.go
+++ b/api/v2/proxy.go
@@ -73,9 +73,9 @@ func (pd *ProxyData) Key(r *http.Request) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("authorize failed, can not confirm the app by request ip")
 			}
-			return appName, nil
+			return fixPrefix(appName), nil
 		}
 		return "", fmt.Errorf("authorize failed, no permission")
 	}
-	return appName, nil
+	return fixPrefix(appName), nil
 }

--- a/api/v2/rebellion_localprocs.go
+++ b/api/v2/rebellion_localprocs.go
@@ -89,9 +89,9 @@ func (ap *RebellionAPIProvider) Key(r *http.Request) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("authorize failed, can not confirm the app by request ip")
 			}
-			return appName, nil
+			return fixPrefix(appName), nil
 		}
 		return "", fmt.Errorf("authorize failed, no permission")
 	}
-	return appName, nil
+	return fixPrefix(appName), nil
 }

--- a/api/v2/utils.go
+++ b/api/v2/utils.go
@@ -1,0 +1,12 @@
+package v2
+
+func fixPrefix(s string) string {
+	l := len(s)
+	if l == 0 {
+		return s
+	}
+	if s[l-1] == '/' {
+		return s
+	}
+	return s + "/"
+}

--- a/api/v2/webrouter_webprocs.go
+++ b/api/v2/webrouter_webprocs.go
@@ -88,9 +88,9 @@ func (wi *WebrouterInfo) Key(r *http.Request) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("authorize failed, can not confirm the app by request ip")
 			}
-			return appName, nil
+			return fixPrefix(appName), nil
 		}
 		return "", fmt.Errorf("authorize failed, no permission")
 	}
-	return appName, nil
+	return fixPrefix(appName), nil
 }

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// the version value
-	version = "2.0.2"
+	version = "2.0.3"
 )
 
 var (


### PR DESCRIPTION
API 利用参数作为前缀模糊匹配的问题，会导致返回获取多余的本不属于自己的数据。
